### PR TITLE
README: add `brew` install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ $ pip install wtfis
 
 To install via `conda` (from conda-forge), see [wtfis-feedstock](https://github.com/conda-forge/wtfis-feedstock).
 
+To install via [`brew`](https://brew.sh):
+```
+brew install wtfis
+```
 
 ## Setup
 


### PR DESCRIPTION
Hello 👋 . I'm a maintainer for the [Homebrew](https://brew.sh) project. I love `wtfis` and have packaged it for users who use our package manager. This PR adds instructions for installing via Homebrew. Thanks!