### PR TITLE
Change default whois provider (partial PT deprecation)

### DIFF
--- a/.env.wtfis.example
+++ b/.env.wtfis.example
@@ -1,8 +1,6 @@
 # Example ~/.env.wtfis file
 # Don't forget to chmod 400!
 VT_API_KEY=foo
-PT_API_KEY=bar
-PT_API_USER=baz@example.com
 IP2WHOIS_API_KEY=alice
 SHODAN_API_KEY=hunter2
 GREYNOISE_API_KEY=upupdowndown

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The project name is a play on "whois".
 | Service | Used in lookup | Required | Free Tier |
 | --- | --- | --- | --- |
 | [Virustotal](https://virustotal.com) | All | Yes | [Yes](https://www.virustotal.com/gui/join-us) |
-| [Passivetotal](https://community.riskiq.com) | All | No | [Yes](https://community.riskiq.com/registration/)
 | [IP2Whois](https://www.ip2whois.com) | Domain/FQDN | No | [Yes](https://www.ip2location.io/pricing#ip2whois)
 | [IPWhois](https://ipwhois.io) | IP address | No | Yes (no signup) |
 | [Shodan](https://shodan.io) | IP address | No | [No](https://account.shodan.io/billing) |
@@ -45,30 +44,21 @@ The primary source of information. Retrieves:
     * Last n IP addresses (default: 3, max: 10)
     * Latest analysis stats of each IP above
 * [Whois](https://developers.virustotal.com/reference/whois)
-    * Fallback only: if Passivetotal creds are not available
+    * Fallback only: if IP2Whois creds are not available
     * Various whois data about the domain itself
-
-### Passivetotal (RiskIQ)
-
-Optionally used if creds are provided. Retrieves:
-
-* [Whois](https://api.riskiq.net/api/whois_pt/)
-    * Various whois data about the domain itself
-
-Passivetotal is recommended over Virustotal for whois data for a couple of reasons:
-
-* VT whois data format is less consistent
-* PT whois data tends to be of better quality than VT. Also, VT's registrant data is apparently [anonymized](https://developers.virustotal.com/reference/whois).
-* You can save one VT API call by offloading to PT
 
 ### IP2Whois
 
-Optionally used if creds are provided and Passivetotal creds are not supplied. (i.e. second in line for Whois information)
+Optionally used if creds are provided. Retrieves:
 
 * [Whois](https://www.ip2location.io/ip2whois-documentation)
     * Various whois data about the domain itself
 
-As above, IP2Whois is recommended over Virustotal if a Passivetotal account cannot be obtained.
+IP2Whois is recommended over Virustotal for whois data for a couple of reasons:
+
+* VT whois data format is less consistent
+* IP2Whois whois data tends to be of better quality than VT. Also, VT's registrant data is apparently [anonymized](https://developers.virustotal.com/reference/whois).
+* You can save one VT API call by offloading to IP2Whois.
 
 ### IPWhois
 
@@ -132,8 +122,6 @@ brew install wtfis
 wtfis uses these environment variables:
 
 * `VT_API_KEY` (required) - Virustotal API key
-* `PT_API_KEY` (optional) - Passivetotal API key
-* `PT_API_USER` (optional) - Passivetotal API user
 * `IP2WHOIS_API_KEY` (optional) - IP2WHOIS API key
 * `SHODAN_API_KEY` (optional) - Shodan API key
 * `GREYNOISE_API_KEY` (optional) - Greynoise API key
@@ -176,7 +164,7 @@ and you will get results organized by panel, similar to the image above.
 
 Defanged input is accepted (e.g. `api[.]google[.]com`).
 
-If supported by the terminal, the `Analysis` field and (if using PT) headings in the whois panel are clickable hyperlinks that point to the appropriate pages on the VT or PT website.
+If the terminal supports it, certain fields and headings are clickable hyperlinks that point to the respective services' websites.
 
 ### Shodan
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,9 @@ disable = true
 [tool.hatch.envs.default]
 dependencies = [
     "bandit",
-    "black~=24.4.2",
-    "flake8>=7.0.0",
-    "flake8-bugbear~=24.4.6",
+    "black~=24.8.0",
+    "flake8>=7.1.2",
+    "flake8-bugbear~=24.12.12",
     "freezegun",
     "isort~=5.13.2",
     "mypy",
@@ -90,9 +90,9 @@ python = ["38", "39", "310", "311", "312", "313"]
 detached = true
 dependencies = [  # Make sure the respective versions are synced with default!
     "bandit",
-    "black~=24.4.2",
-    "flake8>=7.0.0",
-    "flake8-bugbear~=24.4.6",
+    "black~=24.8.0",
+    "flake8>=7.1.2",
+    "flake8-bugbear~=24.12.12",
     "isort~=5.13.2",
 ]
 [tool.hatch.envs.lint.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,6 @@ from wtfis.clients.abuseipdb import AbuseIpDbClient
 from wtfis.clients.greynoise import GreynoiseClient
 from wtfis.clients.ip2whois import Ip2WhoisClient
 from wtfis.clients.ipwhois import IpWhoisClient
-from wtfis.clients.passivetotal import PTClient
 from wtfis.clients.shodan import ShodanClient
 from wtfis.clients.urlhaus import UrlHausClient
 from wtfis.clients.virustotal import VTClient
@@ -485,7 +484,7 @@ class TestGenEntityHandler:
         assert entity.progress == progress
         assert isinstance(entity._vt, VTClient)
         assert isinstance(entity._geoasn, IpWhoisClient)
-        assert isinstance(entity._whois, PTClient)
+        assert isinstance(entity._whois, Ip2WhoisClient)
         assert entity._shodan is None
         assert entity._greynoise is None
         assert entity._urlhaus is None
@@ -502,7 +501,7 @@ class TestGenEntityHandler:
             entity = generate_entity_handler(parse_args(), console, progress)
         assert entity.max_resolutions == 5
         assert isinstance(entity._geoasn, IpWhoisClient)
-        assert isinstance(entity._whois, PTClient)
+        assert isinstance(entity._whois, Ip2WhoisClient)
         assert isinstance(entity._shodan, ShodanClient)
         assert isinstance(entity._greynoise, GreynoiseClient)
         assert isinstance(entity._urlhaus, UrlHausClient)
@@ -544,7 +543,7 @@ class TestGenEntityHandler:
         assert entity.progress == progress
         assert isinstance(entity._vt, VTClient)
         assert isinstance(entity._geoasn, IpWhoisClient)
-        assert isinstance(entity._whois, PTClient)
+        assert isinstance(entity._whois, VTClient)
         assert entity._greynoise is None
         assert entity._urlhaus is None
         unset_env_vars()
@@ -558,7 +557,7 @@ class TestGenEntityHandler:
             progress = (simulate_progress(console),)
             entity = generate_entity_handler(parse_args(), console, progress)
         assert isinstance(entity._geoasn, IpWhoisClient)
-        assert isinstance(entity._whois, PTClient)
+        assert isinstance(entity._whois, VTClient)
         assert isinstance(entity._shodan, ShodanClient)
         assert isinstance(entity._greynoise, GreynoiseClient)
         assert isinstance(entity._urlhaus, UrlHausClient)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -8,8 +8,8 @@ from rich.console import Console
 from wtfis.clients.abuseipdb import AbuseIpDbClient
 from wtfis.clients.base import requests
 from wtfis.clients.greynoise import GreynoiseClient
-from wtfis.clients.ipwhois import IpWhoisClient
 from wtfis.clients.ip2whois import Ip2WhoisClient
+from wtfis.clients.ipwhois import IpWhoisClient
 from wtfis.clients.shodan import ShodanClient
 from wtfis.clients.urlhaus import UrlHausClient
 from wtfis.clients.virustotal import VTClient

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -9,7 +9,7 @@ from wtfis.clients.abuseipdb import AbuseIpDbClient
 from wtfis.clients.base import requests
 from wtfis.clients.greynoise import GreynoiseClient
 from wtfis.clients.ipwhois import IpWhoisClient
-from wtfis.clients.passivetotal import PTClient
+from wtfis.clients.ip2whois import Ip2WhoisClient
 from wtfis.clients.shodan import ShodanClient
 from wtfis.clients.urlhaus import UrlHausClient
 from wtfis.clients.virustotal import VTClient
@@ -27,7 +27,7 @@ def generate_domain_handler(max_resolutions=3):
         progress=MagicMock(),
         vt_client=VTClient("dummykey"),
         ip_geoasn_client=IpWhoisClient(),
-        whois_client=PTClient("dummyuser", "dummykey"),
+        whois_client=Ip2WhoisClient("dummykey"),
         shodan_client=ShodanClient("dummykey"),
         greynoise_client=GreynoiseClient("dummykey"),
         abuseipdb_client=AbuseIpDbClient("dummykey"),
@@ -43,7 +43,7 @@ def generate_ip_handler():
         progress=MagicMock(),
         vt_client=VTClient("dummykey"),
         ip_geoasn_client=IpWhoisClient(),
-        whois_client=PTClient("dummyuser", "dummykey"),
+        whois_client=Ip2WhoisClient("dummykey"),
         shodan_client=ShodanClient("dummykey"),
         greynoise_client=GreynoiseClient("dummykey"),
         abuseipdb_client=AbuseIpDbClient("dummykey"),
@@ -232,16 +232,16 @@ class TestDomainHandler:
         mock_resp.status_code = 401
         mock_requests_get.return_value = mock_resp
 
-        with pytest.raises(SystemExit) as e:
-            handler._fetch_whois()
-
-        capture = capsys.readouterr()
-
-        assert (
-            capture.err == "Error fetching data: 401 Client Error: None for url: None\n"
+        handler._fetch_whois()
+        assert handler.warnings[0].startswith(
+            "Could not fetch IP2Whois: 401 Client Error:"
         )
-        assert e.type == SystemExit
-        assert e.value.code == 1
+
+        handler.print_warnings()
+        capture = capsys.readouterr()
+        assert capture.out.startswith(
+            "WARN: Could not fetch IP2Whois: 401 Client Error:"
+        )
 
     @patch.object(requests.Session, "get")
     def test_vt_resolutions_429_error(self, mock_requests_get, domain_handler, capsys):
@@ -280,12 +280,14 @@ class TestDomainHandler:
 
         handler._fetch_whois()
         assert handler.warnings[0].startswith(
-            "Could not fetch Whois: 429 Client Error:"
+            "Could not fetch IP2Whois: 429 Client Error:"
         )
 
         handler.print_warnings()
         capture = capsys.readouterr()
-        assert capture.out.startswith("WARN: Could not fetch Whois: 429 Client Error:")
+        assert capture.out.startswith(
+            "WARN: Could not fetch IP2Whois: 429 Client Error:"
+        )
 
     @patch.object(requests.Session, "get")
     def test_greynoise_429_error(
@@ -521,16 +523,16 @@ class TestIpAddressHandler:
         mock_resp.status_code = 403
         mock_requests_get.return_value = mock_resp
 
-        with pytest.raises(SystemExit) as e:
-            handler._fetch_whois()
-
-        capture = capsys.readouterr()
-
-        assert (
-            capture.err == "Error fetching data: 403 Client Error: None for url: None\n"
+        handler._fetch_whois()
+        assert handler.warnings[0].startswith(
+            "Could not fetch IP2Whois: 403 Client Error:"
         )
-        assert e.type == SystemExit
-        assert e.value.code == 1
+
+        handler.print_warnings()
+        capture = capsys.readouterr()
+        assert capture.out.startswith(
+            "WARN: Could not fetch IP2Whois: 403 Client Error:"
+        )
 
     @patch.object(requests.Session, "get")
     def test_ipwhois_validation_error(self, mock_requests_get, ip_handler, capsys):
@@ -587,7 +589,7 @@ class TestIpAddressHandler:
         mock_requests_get.return_value = mock_resp
 
         with pytest.raises(SystemExit) as e:
-            handler._fetch_whois()
+            handler._fetch_vt_ip_address()
 
         capture = capsys.readouterr()
 

--- a/wtfis/main.py
+++ b/wtfis/main.py
@@ -12,7 +12,6 @@ from wtfis.clients.abuseipdb import AbuseIpDbClient
 from wtfis.clients.greynoise import GreynoiseClient
 from wtfis.clients.ip2whois import Ip2WhoisClient
 from wtfis.clients.ipwhois import IpWhoisClient
-from wtfis.clients.passivetotal import PTClient
 from wtfis.clients.shodan import ShodanClient
 from wtfis.clients.urlhaus import UrlHausClient
 from wtfis.clients.virustotal import VTClient
@@ -137,15 +136,12 @@ def generate_entity_handler(
 
     # Whois client selector
     # Order of use based on set envvars:
-    #    1. Passivetotal
-    #    2. IP2Whois (Domain only)
+    #    1. IP2Whois (Domain only)
     #    2. Virustotal (fallback)
-    if os.environ.get("PT_API_USER") and os.environ.get("PT_API_KEY"):
-        whois_client: Union[PTClient, Ip2WhoisClient, VTClient] = PTClient(
-            os.environ["PT_API_USER"], os.environ["PT_API_KEY"]
+    if os.environ.get("IP2WHOIS_API_KEY") and not is_ip(args.entity):
+        whois_client: Union[Ip2WhoisClient, VTClient] = Ip2WhoisClient(
+            os.environ["IP2WHOIS_API_KEY"]
         )
-    elif os.environ.get("IP2WHOIS_API_KEY") and not is_ip(args.entity):
-        whois_client = Ip2WhoisClient(os.environ["IP2WHOIS_API_KEY"])
     else:
         whois_client = vt_client
 


### PR DESCRIPTION
Make IP2Whois the default whois provider. Also warn, instead of fail, on whois fetching errors.

Partially addresses #84 (PT is not fully removed here yet)